### PR TITLE
Add service helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ Script to handle power events on the X708 UPS for Raspberry Pi.
 Run the `x708-pwr.sh` script as root to monitor the shutdown and reboot
 buttons. The script automatically cleans up the GPIO pins on exit so it
 can be safely integrated into a service.
+
+## Running as a service
+
+The repository includes a systemd unit file for running the power button
+monitor as a service. Copy the script and service file and enable the
+unit with the following commands:
+
+```bash
+sudo cp x708-pwr.sh /usr/local/bin/
+sudo cp x708-pwr.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable x708-pwr.service
+sudo systemctl start x708-pwr.service
+```

--- a/x708-pwr.service
+++ b/x708-pwr.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monitor X708 shutdown and reboot buttons
+After=multi-user.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/x708-pwr.sh
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- provide a systemd service file for the script
- document how to install and enable the service

## Testing
- `bash -n x708-pwr.sh`
- `shellcheck --version >/dev/null 2>&1 && shellcheck x708-pwr.sh || echo 'shellcheck not available'`

------
https://chatgpt.com/codex/tasks/task_e_6853908a7de4832492ed554517b809d2