### PR TITLE
Fix soft shutdown script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Run the `x708-pwr.sh` script as root to monitor the shutdown and reboot
 buttons. The script automatically cleans up the GPIO pins on exit so it
 can be safely integrated into a service.
 
+Use `x708-softsd.sh` to signal the UPS to cut power after a short delay.
+Pass the delay in seconds as an optional argument (defaults to 4). The
+script must also be run as root.
+
+## Triggering a soft shutdown
+
+Run the soft shutdown script before halting the Pi to let the UPS know it
+should cut power:
+
+```bash
+sudo ./x708-softsd.sh 6
+sudo shutdown -h now
+```
+
 ## Running as a service
 
 The repository includes a systemd unit file for running the power button

--- a/x708-softsd.sh
+++ b/x708-softsd.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [[ $EUID -ne 0 ]]; then
+  echo "Please run as root." >&2
+  exit 1
+fi
+
 BUTTON=13
 
 echo "$BUTTON" > /sys/class/gpio/export

--- a/x708-softsd.sh
+++ b/x708-softsd.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
+set -euo pipefail
 
 BUTTON=13
 
-echo "$BUTTON" > /sys/class/gpio/export;
+echo "$BUTTON" > /sys/class/gpio/export
 echo "out" > /sys/class/gpio/gpio$BUTTON/direction
 echo "1" > /sys/class/gpio/gpio$BUTTON/value
+
+cleanup() {
+  echo "$BUTTON" > /sys/class/gpio/unexport
+}
+
+trap cleanup EXIT
 
 SLEEP=${1:-4}
 
@@ -13,8 +20,8 @@ if ! [[ $SLEEP =~ $re ]] ; then
    echo "error: sleep time not a number" >&2; exit 1
 fi
 
-echo "Your device will shutting down in 4 seconds..."
-/bin/sleep $SLEEP
+echo "Your device will shut down in $SLEEP seconds..."
+/bin/sleep "$SLEEP"
 
 # restore GPIO 13
 echo "0" > /sys/class/gpio/gpio$BUTTON/value


### PR DESCRIPTION
## Summary
- clean up new shutdown script
- add safety options and cleanup trap
- show wait time in messages

## Testing
- `shellcheck x708-softsd.sh`


------
https://chatgpt.com/codex/tasks/task_e_68539625ec6483249be48ccd5c132675