### PR TITLE
Add smbus2 install notes and graceful import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,26 @@ Utilities for handling power events on the X708 UPS for the Raspberry Pi 4.
 Install them on a Debian based system with:
 
 ```bash
-sudo apt-get install gpiod
-pip install smbus2 gpiod
+sudo apt-get install gpiod python3-libgpiod python3-smbus2
+```
+
+If `python3-smbus2` is not available on your system,
+install the package with pip instead:
+
+```bash
+sudo pip3 install smbus2
 ```
 
 ## Scripts
 
 ### x708-pwr.sh
 Monitors the shutdown and reboot buttons. The boot line (GPIO 12) is held
-high using `gpioset` for as long as the script runs.
+high using `gpioset` for as long as the script runs. The script requires
+root privileges because it accesses the GPIO chip.
 
 ### x708-softsd.sh
-Sends a pulse on GPIO 13 to tell the UPS to cut power after a delay.
+Sends a pulse on GPIO 13 to tell the UPS to cut power after a delay. Run as
+root so the script can access the GPIO line.
 
 ```bash
 sudo ./x708-softsd.sh 6
@@ -37,7 +45,8 @@ sudo shutdown -h now
 
 ### bat.py
 Reads battery voltage and capacity over I2C. When the voltage falls below
-3&nbsp;V it toggles the shutdown line via `gpiod`.
+3&nbsp;V it toggles the shutdown line via `gpiod`. This script must also be
+run as root so it can access I2C and GPIO.
 
 ### Running as a service
 

--- a/bat.py
+++ b/bat.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
+import os
 import struct
+import sys
 import time
-from smbus2 import SMBus
+try:
+    from smbus2 import SMBus
+except ImportError as e:
+    sys.exit("The smbus2 module is required. Install it with 'sudo apt-get install python3-smbus2' or 'sudo pip3 install smbus2'.")
 import gpiod
 
 PIN = 13
@@ -30,6 +35,8 @@ def readCapacity(bus):
 
 def main():
     global line
+    if os.geteuid() != 0:
+        sys.exit("Please run as root.")
     try:
         with gpiod.Chip(CHIP) as chip, SMBus(1) as bus:
             line = chip.get_line(PIN)

--- a/x708-pwr.sh
+++ b/x708-pwr.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [[ $EUID -ne 0 ]]; then
+  echo "Please run as root." >&2
+  exit 1
+fi
+
 SHUTDOWN=5
 REBOOTPULSEMINIMUM=200
 REBOOTPULSEMAXIMUM=600


### PR DESCRIPTION
## Summary
- document installing `python3-smbus2`
- fail gracefully if `smbus2` is missing

## Testing
- `python3 -m py_compile bat.py`
- `shellcheck x708-pwr.sh x708-softsd.sh`


------
https://chatgpt.com/codex/tasks/task_e_6853a4dc6bbc8324992abddf6b592507