### PR TITLE
Improve install docs and handle missing libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,24 @@ Utilities for handling power events on the X708 UPS for the Raspberry Pi 4.
 - `gpiod` for the `gpioset`/`gpioget` tools
 - Python 3 with the `smbus2` and `gpiod` packages
 
-Install them on a Debian based system with:
+Install them on a Debian-based system with:
 
 ```bash
-sudo apt-get install gpiod
-pip install smbus2 gpiod
+sudo apt-get install gpiod python3-libgpiod python3-smbus2
+```
+
+If `python3-smbus2` is not available on your system,
+install the package with pip instead:
+
+```bash
+python3 -m pip install smbus2
+```
+
+If `python3-libgpiod` is not available,
+install the `gpiod` Python package with pip:
+
+```bash
+python3 -m pip install gpiod
 ```
 
 ## Scripts
@@ -19,9 +32,11 @@ pip install smbus2 gpiod
 ### x708-pwr.sh
 Monitors the shutdown and reboot buttons. The boot line (GPIO 12) is held
 high using `gpioset` for as long as the script runs.
+Run the script as root so it can access the GPIO chip.
 
 ### x708-softsd.sh
 Sends a pulse on GPIO 13 to tell the UPS to cut power after a delay.
+This script also needs to run as root to access the GPIO line.
 
 ```bash
 sudo ./x708-softsd.sh 6
@@ -37,12 +52,13 @@ sudo shutdown -h now
 
 ### bat.py
 Reads battery voltage and capacity over I2C. When the voltage falls below
-3&nbsp;V it toggles the shutdown line via `gpiod`.
+3&nbsp;V it toggles the shutdown line via `gpiod`. This script must also be
+run as root so it can access I2C and GPIO.
 
 ### Running as a service
 
-The repository includes a systemd unit file. Copy the files and enable the
-unit with:
+The repository includes a systemd unit file. It runs `x708-pwr.sh` as root so
+it can control the GPIO hardware. Copy the files and enable the unit with:
 
 ```bash
 sudo cp x708-pwr.sh /usr/local/bin/

--- a/bat.py
+++ b/bat.py
@@ -1,8 +1,24 @@
 #!/usr/bin/env python3
+import os
 import struct
+import sys
 import time
-from smbus2 import SMBus
-import gpiod
+
+try:
+    from smbus2 import SMBus
+except ImportError:
+    sys.exit(
+        "The smbus2 module is required. Install it with 'sudo apt-get install "
+        "python3-smbus2' or 'python3 -m pip install smbus2'."
+    )
+
+try:
+    import gpiod
+except ImportError:
+    sys.exit(
+        "The gpiod module is required. Install it with 'sudo apt-get install "
+        "python3-libgpiod'."
+    )
 
 PIN = 13
 CHIP = "gpiochip0"
@@ -30,6 +46,8 @@ def readCapacity(bus):
 
 def main():
     global line
+    if os.geteuid() != 0:
+        sys.exit("Please run as root.")
     try:
         with gpiod.Chip(CHIP) as chip, SMBus(1) as bus:
             line = chip.get_line(PIN)

--- a/x708-pwr.sh
+++ b/x708-pwr.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+if [[ $EUID -ne 0 ]]; then
+  echo "Please run as root." >&2
+  exit 1
+fi
+
 SHUTDOWN=5
 REBOOTPULSEMINIMUM=200
 REBOOTPULSEMAXIMUM=600
@@ -28,14 +33,14 @@ while true; do
       /bin/sleep 0.02
       if [ $(( $(date +%s%N | cut -b1-13) - pulseStart )) -gt $REBOOTPULSEMAXIMUM ]; then
         echo "Shutdown button held on GPIO $SHUTDOWN, halting Rpi..."
-        sudo poweroff
+        poweroff
         exit
       fi
       shutdownSignal=$(gpioget gpiochip0 "$SHUTDOWN")
     done
     if [ $(( $(date +%s%N | cut -b1-13) - pulseStart )) -gt $REBOOTPULSEMINIMUM ]; then
       echo "Reboot button pressed on GPIO $SHUTDOWN, rebooting Rpi..."
-      sudo reboot
+      reboot
       exit
     fi
   fi


### PR DESCRIPTION
## Summary
- clean up apt installation instructions
- verify `bat.py` fails gracefully if `gpiod` or `smbus2` aren't installed
- drop unnecessary `sudo` in `x708-pwr.sh`
- document pip fallback for `gpiod`

## Testing
- `python3 -m py_compile bat.py`
- `shellcheck x708-pwr.sh x708-softsd.sh`


------
https://chatgpt.com/codex/tasks/task_e_6853a4dc6bbc8324992abddf6b592507