### PR TITLE
Add bat.py service

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ python3 -m pip install gpiod
 ## Installation script
 
 The repository provides an interactive `install.sh` helper. Run it as root to
-copy the scripts to `/usr/local/bin` and optionally set up the `x708-pwr.sh`
-service. The installer can also install the required `gpiod` and Python
-packages for you.
+copy the scripts to `/usr/local/bin` and optionally set up the services for
+`x708-pwr.sh` and `bat.py`. The installer can also install the required
+`gpiod` and Python packages for you.
 
 ```bash
 sudo ./install.sh
@@ -71,7 +71,7 @@ run as root so it can access I2C and GPIO.
 
 ### Running as a service
 
-The repository includes a systemd unit file. It runs `x708-pwr.sh` as root so
+The repository includes systemd unit files. One runs `x708-pwr.sh` as root so
 it can control the GPIO hardware. Copy the files and enable the unit with:
 
 ```bash
@@ -80,6 +80,17 @@ sudo cp x708-pwr.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable x708-pwr.service
 sudo systemctl start x708-pwr.service
+```
+
+Another unit file runs `bat.py` to monitor the battery level and trigger a
+shutdown when it becomes too low:
+
+```bash
+sudo cp bat.py /usr/local/bin/
+sudo cp x708-bat.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable x708-bat.service
+sudo systemctl start x708-bat.service
 ```
 
 ## Monitoring the UPS battery

--- a/install.sh
+++ b/install.sh
@@ -57,6 +57,17 @@ install_bat() {
   sed -i "s/^PIN = .*/PIN = ${pin:-13}/" "$INSTALL_DIR/bat.py"
   read -p "Shutdown voltage threshold [3.00]: " thr
   sed -i "s/voltage < [0-9.]*:/voltage < ${thr:-3.00}:/" "$INSTALL_DIR/bat.py"
+  read -p "Install bat.py as a service? [y/N] " svc
+  if [[ $svc =~ ^[Yy]$ ]]; then
+    cp x708-bat.service "$SERVICE_DIR/"
+    sed -i "s|ExecStart=.*|ExecStart=$INSTALL_DIR/bat.py|" "$SERVICE_DIR/x708-bat.service"
+    systemctl daemon-reload
+    systemctl enable x708-bat.service
+    read -p "Start service now? [y/N] " startsvc
+    if [[ $startsvc =~ ^[Yy]$ ]]; then
+      systemctl start x708-bat.service
+    fi
+  fi
 }
 
 read -p "Install x708-pwr.sh (monitor buttons)? [y/N] " resp

--- a/x708-bat.service
+++ b/x708-bat.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monitor X708 battery level
+After=multi-user.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/bat.py
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add new x708-bat.service file
- update install.sh to optionally install bat.py as a service
- document bat.py service usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853c409e12c8324aa247449408b1d95