### PR TITLE
Reduce battery polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ sudo shutdown -h now
 ```
 
 ### bat.py
-Reads battery voltage and capacity over I2C. When the voltage falls below
-3&nbsp;V it toggles the shutdown line via `gpiod`. This script must also be
-run as root so it can access I2C and GPIO.
+Reads battery voltage and capacity over I2C once per minute. When the voltage
+falls below 3&nbsp;V it toggles the shutdown line via `gpiod`. This script must
+also be run as root so it can access I2C and GPIO.
 
 ### Running as a service
 
@@ -96,8 +96,8 @@ sudo systemctl start x708-bat.service
 ## Monitoring the UPS battery
 
 `bat.py` reads the battery voltage and capacity from the X708 over I2C using
-`smbus2`. When the voltage drops below 3&nbsp;V the script toggles the shutdown
-line via `gpiod`. Run it as root:
+`smbus2`. It polls once per minute and when the voltage drops below 3&nbsp;V the
+script toggles the shutdown line via `gpiod`. Run it as root:
 
 ```bash
 sudo python3 bat.py

--- a/bat.py
+++ b/bat.py
@@ -23,6 +23,10 @@ except ImportError:
 PIN = 13
 CHIP = "gpiochip0"
 
+# How often to check the battery state. The Pi can run on battery for hours
+# so reading once per minute is sufficient.
+CHECK_INTERVAL = 60
+
 line = None
 
 
@@ -78,7 +82,7 @@ def main():
                     time.sleep(3)
                     line.set_value(0)
 
-                time.sleep(2)
+                time.sleep(CHECK_INTERVAL)
     except KeyboardInterrupt:
         print("Exiting...")
     finally:


### PR DESCRIPTION
## Summary
- poll the UPS battery once per minute instead of every two seconds
- document the new battery check interval

## Testing
- `python3 -m py_compile bat.py`


------
https://chatgpt.com/codex/tasks/task_e_6855087596308324bdf0ba0dae7aac06