### PR TITLE
Fix gpioset background handling

### DIFF
--- a/x708-pwr.sh
+++ b/x708-pwr.sh
@@ -18,7 +18,7 @@ REBOOTPULSEMAXIMUM=600
 BOOT=12
 
 # Keep the boot line asserted while running
-gpioset --mode=signal --background gpiochip0 $BOOT=1
+gpioset --mode=signal gpiochip0 "$BOOT=1" &
 boot_pid=$!
 
 cleanup() {


### PR DESCRIPTION
## Summary
- run gpioset in the background using `&`

## Testing
- `shellcheck x708-pwr.sh`
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68574a9d50e88324ae8486e36ce66ca7