### PR TITLE
Improve error handling

### DIFF
--- a/bat.py
+++ b/bat.py
@@ -53,7 +53,17 @@ def main():
     if os.geteuid() != 0:
         sys.exit("Please run as root.")
     try:
-        with gpiod.Chip(CHIP) as chip, SMBus(1) as bus:
+        chip = gpiod.Chip(CHIP)
+    except OSError as e:
+        sys.exit(f"Failed to open GPIO chip '{CHIP}': {e}")
+
+    try:
+        bus = SMBus(1)
+    except (FileNotFoundError, OSError) as e:
+        sys.exit(f"Failed to open I\u00b2C bus: {e}")
+
+    try:
+        with chip, bus:
             line = chip.get_line(PIN)
             line.request(consumer="x708_bat", type=gpiod.LINE_REQ_DIR_OUT, default_vals=[0])
 

--- a/fan.py
+++ b/fan.py
@@ -49,7 +49,12 @@ if __name__ == '__main__':
     if os.geteuid() != 0:
         sys.exit('Please run as root.')
 
-    with gpiod.Chip(CHIP) as chip:
+    try:
+        chip = gpiod.Chip(CHIP)
+    except OSError as e:
+        sys.exit(f"Failed to open GPIO chip '{CHIP}': {e}")
+
+    with chip:
         line = chip.get_line(GPIO_PIN)
         line.request(consumer='fan_ctrl', type=gpiod.LINE_REQ_DIR_OUT, default_vals=[0])
 

--- a/x708-pwr.sh
+++ b/x708-pwr.sh
@@ -27,13 +27,18 @@ cleanup() {
 }
 
 # Keep the boot line asserted while running
-gpioset --mode=signal gpiochip0 "$BOOT=1" &
+err_file="$(mktemp)"
+gpioset --mode=signal gpiochip0 "$BOOT=1" 2>"$err_file" &
 boot_pid=$!
 
+sleep 0.1
 if ! kill -0 "$boot_pid" 2>/dev/null; then
-  echo "Failed to start gpioset" >&2
+  echo "Failed to start gpioset:" >&2
+  cat "$err_file" >&2
+  rm -f "$err_file"
   exit 1
 fi
+rm -f "$err_file"
 
 trap cleanup EXIT
 


### PR DESCRIPTION
## Summary
- exit with descriptive message if opening the GPIO chip or I²C bus fails
- show gpioset errors in the journal

## Testing
- `python3 -m py_compile bat.py fan.py`
- `shellcheck x708-pwr.sh`


------
https://chatgpt.com/codex/tasks/task_e_68575c8a3c988324b5e6e624872680f7