### PR TITLE
Allow GPIO chip path override

### DIFF
--- a/bat.py
+++ b/bat.py
@@ -21,7 +21,9 @@ except ImportError:
     )
 
 PIN = 13
-CHIP = "gpiochip0"
+# Allow overriding the GPIO chip path with the GPIO_CHIP environment variable.
+# Default to using /dev/gpiochip0 which works on most systems.
+CHIP = os.environ.get("GPIO_CHIP", "/dev/gpiochip0")
 
 # How often to check the battery state. The Pi can run on battery for hours
 # so reading once per minute is sufficient.
@@ -53,7 +55,7 @@ def main():
     if os.geteuid() != 0:
         sys.exit("Please run as root.")
     try:
-        chip = gpiod.Chip(CHIP)
+        chip = gpiod.Chip(CHIP, gpiod.Chip.OPEN_BY_PATH)
     except OSError as e:
         sys.exit(f"Failed to open GPIO chip '{CHIP}': {e}")
 

--- a/fan.py
+++ b/fan.py
@@ -24,7 +24,9 @@ ON_THRESHOLD = 55  # (degrees Celsius) Fan turns on above this temperature.
 OFF_THRESHOLD = 50  # (degrees Celsius) Fan turns off below this temperature.
 SLEEP_INTERVAL = 5  # (seconds) How often to check the core temperature.
 GPIO_PIN = 16  # GPIO pin used to control the fan.
-CHIP = "gpiochip0"
+# Allow overriding the GPIO chip path with the GPIO_CHIP environment variable.
+# Default to using /dev/gpiochip0 which works on most systems.
+CHIP = os.environ.get("GPIO_CHIP", "/dev/gpiochip0")
 
 
 def get_temp():
@@ -50,7 +52,7 @@ if __name__ == '__main__':
         sys.exit('Please run as root.')
 
     try:
-        chip = gpiod.Chip(CHIP)
+        chip = gpiod.Chip(CHIP, gpiod.Chip.OPEN_BY_PATH)
     except OSError as e:
         sys.exit(f"Failed to open GPIO chip '{CHIP}': {e}")
 


### PR DESCRIPTION
## Summary
- allow overriding chip path with `GPIO_CHIP` env var
- open the GPIO chip by path in the Python helpers

## Testing
- `python3 -m py_compile bat.py fan.py`

------
https://chatgpt.com/codex/tasks/task_e_68576231e5f0832486af09ca44f97713