### PR TITLE
Add gpiod path check and env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ temperature falls below a lower threshold. Run the script as root so it can
 access the GPIO line. A `fan.service` unit is provided to run it
 automatically.
 
+Both Python scripts open `/dev/gpiochip0` by default. Set the `GPIO_CHIP`
+environment variable to point at a different chip path if needed. They check
+for `gpiod.Chip.OPEN_BY_PATH` and fall back to the older constructor when the
+flag is missing so that either gpiod 1.x or 2.x can be used.
+
 ### Running as a service
 
 The repository includes systemd unit files. One runs `x708-pwr.sh` as root so

--- a/bat.py
+++ b/bat.py
@@ -55,9 +55,15 @@ def main():
     if os.geteuid() != 0:
         sys.exit("Please run as root.")
     try:
-        chip = gpiod.Chip(CHIP, gpiod.Chip.OPEN_BY_PATH)
+        if hasattr(gpiod.Chip, "OPEN_BY_PATH"):
+            chip = gpiod.Chip(CHIP, gpiod.Chip.OPEN_BY_PATH)
+        else:  # gpiod 1.x
+            chip = gpiod.Chip(CHIP)
     except OSError as e:
-        sys.exit(f"Failed to open GPIO chip '{CHIP}': {e}")
+        sys.exit(
+            f"Failed to open GPIO chip '{CHIP}'. "
+            f"Set GPIO_CHIP if the path is different: {e}"
+        )
 
     try:
         bus = SMBus(1)

--- a/fan.py
+++ b/fan.py
@@ -52,9 +52,15 @@ if __name__ == '__main__':
         sys.exit('Please run as root.')
 
     try:
-        chip = gpiod.Chip(CHIP, gpiod.Chip.OPEN_BY_PATH)
+        if hasattr(gpiod.Chip, "OPEN_BY_PATH"):
+            chip = gpiod.Chip(CHIP, gpiod.Chip.OPEN_BY_PATH)
+        else:  # gpiod 1.x
+            chip = gpiod.Chip(CHIP)
     except OSError as e:
-        sys.exit(f"Failed to open GPIO chip '{CHIP}': {e}")
+        sys.exit(
+            f"Failed to open GPIO chip '{CHIP}'. "
+            f"Set GPIO_CHIP if the path is different: {e}"
+        )
 
     with chip:
         line = chip.get_line(GPIO_PIN)


### PR DESCRIPTION
## Summary
- open GPIO chip with OPEN_BY_PATH when available
- fall back to gpiod 1.x constructor
- clarify failure message and document GPIO_CHIP environment variable

## Testing
- `python3 -m py_compile bat.py fan.py`

------
https://chatgpt.com/codex/tasks/task_e_6857650e82b483249e8c4c46e2fa7c74