### PR TITLE
Add startup delay for services

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ sudo systemctl enable fan.service
 sudo systemctl start fan.service
 ```
 
+Both `x708-bat.service` and `fan.service` include an
+`ExecStartPre=/bin/sleep 5` directive. This short delay gives the system
+time to initialize the GPIO and I²C devices after boot before the Python
+scripts start.
+
 ## Monitoring the UPS battery
 
 ### Enabling the I²C interface

--- a/fan.service
+++ b/fan.service
@@ -4,6 +4,7 @@ After=multi-user.target
 
 [Service]
 Type=simple
+ExecStartPre=/bin/sleep 5
 ExecStart=/usr/local/bin/fan.py
 Restart=on-failure
 

--- a/x708-bat.service
+++ b/x708-bat.service
@@ -4,6 +4,7 @@ After=multi-user.target
 
 [Service]
 Type=simple
+ExecStartPre=/bin/sleep 5
 ExecStart=/usr/local/bin/bat.py
 Restart=on-failure
 


### PR DESCRIPTION
## Summary
- add `ExecStartPre=/bin/sleep 5` to `x708-bat.service` and `fan.service`
- document the startup delay in `README.md`

## Testing
- `shellcheck *.sh`
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685767c3ff9883248326d42d7f691133