### PR TITLE
Fix fractional input bug in poweroff helper

### DIFF
--- a/x708-softsd.sh
+++ b/x708-softsd.sh
@@ -35,4 +35,9 @@ else
   usec=${usec:0:6}
 fi
 
+# Handle numbers without an integer part (e.g. ".5")
+if [[ -z "$secs" ]]; then
+  secs=0
+fi
+
 gpioset --mode=time --sec="$secs" --usec="$usec" "$GPIO_CHIP" "$BUTTON=1"


### PR DESCRIPTION
## Summary
- handle fractional seconds without an integer part in `x708-softsd.sh`

## Testing
- `shellcheck x708-pwr.sh x708-softsd.sh x708-bat.sh x708-fan.sh install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6857b6569e348324950d39e0d1e25707