### PR TITLE
Add diagnostic script for services and battery status

### DIFF
--- a/x708-status.sh
+++ b/x708-status.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -euo pipefail
+
+# Allow overriding the I2C bus used for battery reads
+BUS=${BUS:-1}
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Please run as root." >&2
+  exit 1
+fi
+
+for cmd in systemctl i2cget; do
+  if ! command -v "$cmd" >/dev/null; then
+    echo "$cmd not found; please install required packages." >&2
+    exit 1
+  fi
+done
+
+read_word_swapped() {
+  local addr=$1 reg=$2
+  local raw
+  raw=$(i2cget -y "$BUS" "$addr" "$reg" w)
+  raw=$((raw))
+  echo $(( ((raw & 0xFF) << 8) | (raw >> 8) ))
+}
+
+read_voltage() {
+  local val
+  val=$(read_word_swapped 0x36 0x02)
+  awk -v v="$val" 'BEGIN { printf "%.2f", v * 1.25 / 1000 / 16 }'
+}
+
+read_capacity() {
+  local val cap
+  val=$(read_word_swapped 0x36 0x04)
+  cap=$(awk -v v="$val" 'BEGIN { printf "%d", v / 256 }')
+  if (( cap > 100 )); then
+    cap=100
+  fi
+  echo "$cap"
+}
+
+show_service_status() {
+  local svc=$1
+  echo "$svc: $(systemctl is-active "$svc" 2>/dev/null || echo unknown)"
+  echo "  Enabled: $(systemctl is-enabled "$svc" 2>/dev/null || echo unknown)"
+}
+
+services=(x708-pwr.service x708-bat.service x708-fan.service)
+
+echo "=== Service Status ==="
+for svc in "${services[@]}"; do
+  show_service_status "$svc"
+done
+
+echo
+echo "=== Battery Status ==="
+voltage=$(read_voltage)
+capacity=$(read_capacity)
+printf "Voltage: %.2f V\n" "$voltage"
+printf "Capacity: %d%%\n" "$capacity"


### PR DESCRIPTION
## Summary
- add `x708-status.sh` to check service states and print battery info

## Testing
- `shellcheck x708-status.sh`


------
https://chatgpt.com/codex/tasks/task_e_6857bb86c7a88324881c70320b628d28