### PR TITLE
Improve installer update flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ sudo apt-get install gpiod i2c-tools libraspberrypi-bin
 
 The repository provides an interactive `install.sh` helper. Run it as root to
 copy the scripts to `/usr/local/bin` and optionally set up the services for
-`x708-pwr.sh`, `x708-bat.sh`, and `x708-fan.sh`. After choosing which scripts to
-install, the helper offers to install only the packages needed for them.
+`x708-pwr.sh`, `x708-bat.sh`, and `x708-fan.sh`. After selecting the scripts to
+install, the helper installs all required packages first and then copies the
+files. If the services are already running, the installer stops them so the
+scripts and unit files can be updated in place.
 
 ```bash
 sudo ./install.sh


### PR DESCRIPTION
## Summary
- stop running services before overwriting scripts or unit files
- gather package dependencies early and install them before copying scripts
- let the installer update existing services in place
- document new behaviour in README

## Testing
- `shellcheck install.sh`
- `python3 -m py_compile $(git ls-files '*.py')` *(no files to check)*

------
https://chatgpt.com/codex/tasks/task_e_6857c1bcfc108324957439750fd7a24a