### PR TITLE
Add journal logging for fan state

### DIFF
--- a/x708-fan.sh
+++ b/x708-fan.sh
@@ -40,6 +40,7 @@ start_fan() {
   gpioset --mode=signal "$GPIO_CHIP" "$GPIO_PIN=1" &
   fan_pid=$!
   state=1
+  logger -t x708-fan "Fan turned on"
 }
 
 stop_fan() {
@@ -47,6 +48,7 @@ stop_fan() {
   gpioset --mode=signal "$GPIO_CHIP" "$GPIO_PIN=0" &
   fan_pid=$!
   state=0
+  logger -t x708-fan "Fan turned off"
 }
 
 state=0


### PR DESCRIPTION
## Summary
- log when the X708 fan turns on or off so the system journal tracks state changes

## Testing
- `shellcheck x708-fan.sh`

------
https://chatgpt.com/codex/tasks/task_e_6857c61ced64832487ef3e615c0d43f5