### PR TITLE
Fix status script fan check

### DIFF
--- a/x708-status.sh
+++ b/x708-status.sh
@@ -55,7 +55,7 @@ read_fan_state() {
   local last
   # Find the most recent ON/OFF line in the service journal.
   if last=$(journalctl -u x708-fan.service --no-pager --no-legend -r 2>/dev/null \
-      | grep -m1 -E "Fan (ON|OFF)"); then
+      | grep -E "Fan (ON|OFF)" | head -n1); then
     if [[ $last == *"Fan ON"* ]]; then
       echo "ON"
     elif [[ $last == *"Fan OFF"* ]]; then


### PR DESCRIPTION
## Summary
- tweak `read_fan_state` to avoid SIGPIPE by using `head -n1`

## Testing
- `shellcheck x708-status.sh`


------
https://chatgpt.com/codex/tasks/task_e_68589dc74c2c832496257c1bc4ca9317