### PR TITLE
Add systemd shutdown hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Existing services are stopped automatically so scripts can be updated.
 ## Scripts
 - **x708-pwr.sh** – monitor the shutdown and reboot buttons.
 - **x708-softsd.sh** – pulse GPIO 13 to cut power after a delay.
+- **x708-shutdown-hook.sh** – optional systemd hook to call `x708-softsd.sh`
+  when the system powers off.
 - **x708-bat.sh** – read the battery over I²C, detect AC power loss, and shut down when low.
 - **x708-fan.sh** – switch the fan between low and high speed based on CPU temperature.
 - **x708-status.sh** – show battery status, fan state, AC power state, and service state.

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,14 @@ install_packages() {
   fi
 }
 
+install_shutdown_hook() {
+  echo "Installing systemd shutdown hook..."
+  local dir="/lib/systemd/system-shutdown"
+  mkdir -p "$dir"
+  cp x708-shutdown-hook.sh "$dir/x708-softsd"
+  chmod +x "$dir/x708-softsd"
+}
+
 install_x708_pwr() {
   echo "Installing x708-pwr.sh..."
   stop_service_if_running x708-pwr.service
@@ -86,6 +94,10 @@ install_x708_softsd() {
   chmod +x "$INSTALL_DIR/x708-softsd.sh"
   read -r -p "GPIO for power cut signal [13]: " button
   sed -i "s/^BUTTON=.*/BUTTON=${button:-13}/" "$INSTALL_DIR/x708-softsd.sh"
+  read -r -p "Install shutdown hook to run on poweroff? [y/N] " hook
+  if [[ $hook =~ ^[Yy]$ ]]; then
+    install_shutdown_hook
+  fi
 }
 
 install_bat() {

--- a/x708-shutdown-hook.sh
+++ b/x708-shutdown-hook.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Shutdown hook to pulse the X708 power-off signal.
+# Runs in the final stage of shutdown with the root filesystem read-only.
+# Only act on an actual power-off, not a reboot.
+[ "$1" = "poweroff" ] || exit 0
+/usr/local/bin/x708-softsd.sh 4
+


### PR DESCRIPTION
## Summary
- add a systemd shutdown hook script that calls `x708-softsd.sh`
- install the hook via `install.sh`
- document the new hook in the README

## Testing
- `shellcheck install.sh`
- `shellcheck x708-shutdown-hook.sh`


------
https://chatgpt.com/codex/tasks/task_e_6858d26c26c88324971ec727c37d329c